### PR TITLE
Update readme to reflect parity repository moved

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Install mongodb:
 
 Orbiter needs Pairty to trace the internal transactions on Musicoin blockchain. Download [Parity](https://github.com/paritytech/parity/releases/latest) then run a private chain up with:
 
-`parity --chain mus.json --tracing on --dapps-port 8848`
+`parity --chain mc.json --tracing on --dapps-port 8848`
 
 the newest version of chain spec of Musicoin can be found [here](https://github.com/Musicoin/orbiter/blob/master/mc.json).
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install mongodb:
 
 ## Running Up Parity
 
-Orbiter needs Pairty to trace the internal transactions on Musicoin blockchain. Download [Parity](https://github.com/ethcore/parity/releases) then run a private chain up with:
+Orbiter needs Pairty to trace the internal transactions on Musicoin blockchain. Download [Parity](https://github.com/paritytech/parity/releases/latest) then run a private chain up with:
 
 `parity --chain mus.json --tracing on --dapps-port 8848`
 


### PR DESCRIPTION
- Update readme to reflect parity repository moved (renamed from ethcore to paritytech)

Also, feel free to submit a PR to parity to include the musicoin chain configuration.